### PR TITLE
REF: Unused container detection and warning

### DIFF
--- a/xcpEngine
+++ b/xcpEngine
@@ -4,15 +4,6 @@
 #  ⊗  ⊗  ⊗  ⊗  ⊗  ⊗  ⊗  ⊗  ⊗  ⊗  ⊗  ⊗  ⊗  ⊗  ⊗  ⊗  ⊗  ⊗  ⊗  ⊗  ⊗  #
 ###################################################################
 source $FSLDIR/etc/fslconf/fsl.sh
-IN_CONTAINER=0
-
-if [[ -d /xcpEngine ]]
-then
-  IN_CONTAINER=1
-  source activate neuro
-  echo "[Detected that xcp is in a container]"
-fi
-export IN_CONTAINER
 
 echo "Received options:" $@
 args=`echo $@`


### PR DESCRIPTION
xcpEngine routinely produces a warning of
`/xcpEngine/xcpEngine: line 12: activate: No such file or directory`

It looks like use of conda was phased out of the Docker built a while ago, which is causing this warning to pop up.

Additionally, the container detection isn't used for anything else, so it looks like the entire block is unnecessary.