### PR TITLE
new features 

### DIFF
--- a/designs/fc-36p.dsn
+++ b/designs/fc-36p.dsn
@@ -70,7 +70,6 @@ confound2_sq[2]=2
 confound2_custom[2]=
 confound2_censor[2]=0
 confound2_censor_contig[2]=0
-confound2_framewise[2]=fds:0.167,dv:2
 confound2_rerun[2]=0
 confound2_cleanup[2]=1
 

--- a/designs/fc-36p_despike.dsn
+++ b/designs/fc-36p_despike.dsn
@@ -69,7 +69,6 @@ confound2_sq[2]=2
 confound2_custom[2]=
 confound2_censor[2]=0
 confound2_censor_contig[2]=0
-confound2_framewise[2]=fds:0.167,dv:2
 confound2_rerun[2]=1
 confound2_cleanup[2]=1
 

--- a/docs/modules/gmd.rst
+++ b/docs/modules/gmd.rst
@@ -42,8 +42,16 @@ temporary files will be retained to facilitate error diagnosis.::
 ``Expected outputs``
 ^^^^^^^^^^^^^^^^^^^^^
 The expected outputs from `gmd` include the following::
+
+ - prefix_gmd.nii.gz # grey matter density
  - prefix_probabilityCSF.nii.gz  # CSF probability map
  - prefix_probabilityGM.nii.gz   # grey matter probability map
  - prefix_probabilityWM.nii.gz  # white matter probability map
  - prefix_raw.nii.gz   # raw image 
  - prefix_segmentation3class.nii.gz  # 3-class tissue segmentation
+
+if the freesurfer is included in the struc module, cifti  files are generated for GM:: 
+
+ - prefix_gmd_rh.cort.gii # right gmd surface
+ - prefix_gmd_lh.cort.gii # left gmd surface
+ - prefix_gmd.dscalar.nii # scalar values of right and left hemispheres 

--- a/docs/modules/index.rst
+++ b/docs/modules/index.rst
@@ -49,7 +49,7 @@ Anatomical derivatives
 
 Modules that generate derivative maps from anatomical data.
 
- * ``jlf``: Uses the ANTs Joint Label Fusion algorithm to produce a
+ * :ref:`jlf`:: Uses the ANTs Joint Label Fusion algorithm to produce a
    high-resolution anatomical segmentation of the subject’s anatomical data. Generates a
    subject-specific atlas of anatomical landmarks that can be used for regional quantification or
    network mapping.
@@ -122,6 +122,7 @@ Quick Lookup
   seed
   task
   struc
+  jlf
   gmd
   norm
   roiquant

--- a/docs/modules/jlf.rst 
+++ b/docs/modules/jlf.rst 
@@ -1,0 +1,54 @@
+.. _jlf:
+
+``jlf``
+===========
+
+``jlf`` is a module that  uses the ANTs Joint Label Fusion algorithm to produce a
+   high-resolution anatomical segmentation of the subject’s anatomical data. Generates a
+   subject-specific atlas of anatomical landmarks that can be used for regional quantification or
+   network mapping. Presently, the module uses atlases of 103-OASIS labels. 
+
+
+``jlf`` options 
+^^^^^^^^^^^^^^^^^
+
+If to use OASIS atlas labels with skullstrip or not::
+
+  - jlf_extract[cxt]=1 # with skulltrip
+
+If to keep each warped atlas, that is not advisable, it occupy space::
+
+  - jlf_keep_warps[cxt]=0 # dont keep 
+
+Fast joint label fusion is no recommended bcos of poor accuracy::
+
+  - jlf_quick[cxt]=1 # for fast jlf but no recommended
+
+The cohort of OASIS label can be selected based on their ages::
+
+  - jlf_cohort[cxt]=All # Everyone  
+  - jlf_cohort[cxt]=YoungAdult22  # Age range of 18-34
+  - jlf_cohort[cxt]=Older18  # Age range of 23-90
+  - jlf_cohort[cxt]=SexBalanced20  #All male subjects (ages 20-68) plus 10 of the female subjects.
+  - jlf_cohort[cxt]=Subset24 # A subset for general use, slightly more balanced on sex
+  - jlf_cohort[cxt]=Younger24 #Maintains the same 2:1 female:male ratio of the original, but biased towards younger subjects
+
+Tthe number of cpu cores, the default is 2::
+
+  - jlf_ncpu[cxt]=2
+
+Configuring parallelisation,very fast:: 
+   
+  - jlf_parallel[3]=1
+
+
+
+Outputs
+^^^^^^^^
+The expected outputs are::
+
+ - prefix_Intensity.nii.gz # atlas intensity 
+ - prefix_Labels.nii.gz # atlas labels
+ - prefix_TargetMaskImageOr.nii.gz # target mask that cover all atlas 
+ - prefix_LabelsGMIntersect.nii.gz # refined atlas with grey matter mask 
+ 

--- a/docs/modules/struc.rst
+++ b/docs/modules/struc.rst
@@ -227,6 +227,20 @@ fractional intensity threshold should be a positive number greater than 0 and le
   # Fractional intensity threshold of 0.3
   struc_fit[cxt]=0.3
 
+Freesufer run.
+
+Routine: ``FSF``
+
+The freesufer can be run with addition of `FSF` to the procsess as ::
+
+  struc_process[cxt]=FSF-ACT
+
+If the freesufer has be ran before, the directory of freesufer can be copied by including::
+
+  struc_freesurferdir[cxt]=/path/to/freesufer/directory
+this can also be included in the cohort file.
+the cifti files for cortical thickness are generated.  
+
 ``struc_quick``
 ~~~~~~~~~~~~~~~~~~
 
@@ -303,3 +317,4 @@ Permitted codes include:
  * ``FBE``: FSL brain extraction
  * ``SEG``: Atropos image segmentation
  * ``REG``: registration to a template
+ * ``FSF``: Freesufer  or copy freesufer outputs from fmriprep if available

--- a/docs/qualitycontrol.rst
+++ b/docs/qualitycontrol.rst
@@ -19,7 +19,22 @@ Normalization of T1w/Functional to Template:
          - normCrossCorr - cross correlation 
          - normJaccard - Jaccard index 
          - normDice - Dice index
-         - normCoverage - Coverage index  
+         - normCoverage - Coverage index 
+
+QC for anatomical:
+         - euler_number_rh,euler_number_lh -  Eurler number if freesurfer is included 
+         - meanGMD - mean of Grey matter density
+         - SignalToNoiseRatio - grey matter signal to noise ratio 
+         - BackgroundKurtosis - background intensity Kurtosis
+         - GreyMatterKurtosis - grey matter intensity Kurtosis
+         - EntropyFocusCriterion - entropy focus criterion ( for ghost signals)
+         - CorticalContrasts - coritical contrasts between white matter and grey matter signals
+         - FGBGEnergyRatio - Foreground-to-background energy ratio
+         - ContrastToNoiseRatio - contrast to noise ratio
+         - WhiteMatterSkewness - WhiteMatter Skewness
+         - BackgroundSkewness - background intensity Kurtosis
+
+
 
 Motion/spikes summary.::
          - relMeansRMSMotion - mean value of RMS motion 

--- a/modules/struc/struc.mod
+++ b/modules/struc/struc.mod
@@ -84,7 +84,8 @@ qc reg_cross_corr regCrossCorr      ${prefix}_regCrossCorr.txt
 qc reg_coverage   regCoverage       ${prefix}_regCoverage.txt
 qc reg_jaccard    regJaccard        ${prefix}_regJaccard.txt
 qc reg_dice       regDice           ${prefix}_regDice.txt
-qc euler_number   eulernumber       ${prefix}_eulernumber.txt
+qc euler_rh_number   euler_number_rh       ${prefix}_rh_eulernumber.txt
+qc euler_lh_number   euler_number_lh       ${prefix}_lh_eulernumber.txt
 
 input image mask
 input image segmentation
@@ -494,13 +495,13 @@ while (( ${#rem} > 0 ))
    
    freesurferdir=${outdir}/freesurfer 
 
-    if [[  -d ${struc_fmriprepdir[cxt]}/ ]]
+    if [[  -d ${struc_freesurferdir[cxt]}/ ]]
      then 
-         fmriprepout=${struc_fmriprepdir[cxt]} 
+         fmriprepout=${struc_freesurferdir[cxt]} 
          
-    elif [[ -d ${struc_fmriprepdir[sub]}/ ]] 
+    elif [[ -d ${struc_freesurferdir[sub]}/ ]] 
        then
-         fmriprepout=${struc_fmriprepdir[sub]} 
+         fmriprepout=${struc_freesurferdir[sub]} 
     fi 
 
 
@@ -513,8 +514,10 @@ while (( ${#rem} > 0 ))
        exec_sys cp -r $FREESURFER_HOME/subjects/fsaverage5  $SUBJECTS_DIR/
        ${FREESURFER_HOME}/bin/mris_euler_number -o  /tmp/text_lh.tsv  ${SUBJECTS_DIR}/${subjectid}/surf/lh.orig.nofix
        ${FREESURFER_HOME}/bin/mris_euler_number -o  /tmp/text_rh.tsv  ${SUBJECTS_DIR}/${subjectid}/surf/rh.orig.nofix
-       eulernumber=$(expr $(cat /tmp/text_lh.tsv)  +  $(cat /tmp/text_rh.tsv))
-       exec_sys echo ${eulernumber} > ${euler_number[cxt]}
+       eulerlh=$(cat /tmp/text_lh.tsv)  
+       eulerrh=$(cat /tmp/text_rh.tsv)  
+       exec_sys echo ${eulerrh} > ${euler_rh_number[cxt]}
+       exec_sys echo ${eulerlh} > ${euler_lh_number[cxt]}
        exec_sys rm  -rf /tmp/text_*.tsv
 
     else 
@@ -527,10 +530,12 @@ while (( ${#rem} > 0 ))
       ${FREESURFER_HOME}/bin/recon-all -subjid ${subjectid} \
       -i ${img[sub]} -all -sd ${SUBJECTS_DIR}
       exec_sys cp -r $FREESURFER_HOME/subjects/fsaverage5 $SUBJECTS_DIR/
-       ${FREESURFER_HOME}/bin/mris_euler_number -o  /tmp/text_lh.tsv  ${SUBJECTS_DIR}/${subjectid}/lh.orig.nofix
-       ${FREESURFER_HOME}/bin/mris_euler_number -o  /tmp/text_rh.tsv  ${SUBJECTS_DIR}/${subjectid}/rh.orig.nofix
-       eulernumber=$(expr $(cat /tmp/text_lh.tsv)  +  $(cat /tmp/text_rh.tsv))
-       exec_sys echo ${eulernumber} > ${euler_number[cxt]}
+       ${FREESURFER_HOME}/bin/mris_euler_number -o  /tmp/text_lh.tsv  ${SUBJECTS_DIR}/${subjectid}/surf/lh.orig.nofix
+       ${FREESURFER_HOME}/bin/mris_euler_number -o  /tmp/text_rh.tsv  ${SUBJECTS_DIR}/${subjectid}/surf/rh.orig.nofix
+       eulerlh=$(cat /tmp/text_lh.tsv)  
+       eulerrh=$(cat /tmp/text_rh.tsv)  
+       exec_sys echo ${eulerrh} > ${euler_rh_number[cxt]}
+       exec_sys echo ${eulerlh} > ${euler_lh_number[cxt]}
        exec_sys rm  -rf /tmp/text_*.tsv
 
    fi 


### PR DESCRIPTION
1. copy freesurfer  from fmirprep/freesufer outputs or option to run fresh freesurfer if wanted::  
  . ``struc_process[cxt]=FSF-ACT``  - FSF for freesurfer 
  .  include `struc_freesurferdir[cxt]='path to freesufer dir` in design file
 .  cifti files for cortical thickness and gmd are generated if FSF is included in the `process`. 
 . euler number in structural qc
 
2. qcanat activated and working!!!
  QC for anatomical:
         - euler_number_rh,euler_number_lh -  Eurler number if freesurfer is included 
         - meanGMD - mean of Grey matter density
         - SignalToNoiseRatio - grey matter signal to noise ratio 
         - BackgroundKurtosis - background intensity Kurtosis
         - GreyMatterKurtosis - grey matter intensity Kurtosis
         - EntropyFocusCriterion - entropy focus criterion ( for ghost signals)
         - CorticalContrasts - coritical contrasts between white matter and grey matter signals
         - FGBGEnergyRatio - Foreground-to-background energy ratio
         - ContrastToNoiseRatio - contrast to noise ratio
         - WhiteMatterSkewness - WhiteMatter Skewness
         - BackgroundSkewness - background intensity Kurtosis

3. JLF is configured  for multi-parallelism  option. this is  useful for HPC and flywheel. the number of cpu cores can be specified  in the  design file: `jlf_ncpu[cxt]=2` . 2 is default. Parallel configuration  is much faster 

4. the documentation for jlf is activated, struc, gmd, task, qcanat and qc documentations  are updated 

5.  fcon design files are updated to remove framewise threshold where  it is not needed. Only required for scrubbing. 

6. task confound can include other confound  regressors other than basic 6 motion parameters ( check documentation ). Computing functional connectivity, reho and alff from task is also possible.
 
7. if fmriprep output has freesurfer, ,the residualized bold   and  res4d (from task)  are  converted to cifti files as additional outputs. 

8. task,fcon documentation is updated 
