### PR TITLE
Allow for fmriprep resolution tags

### DIFF
--- a/modules/prestats/prestats.mod
+++ b/modules/prestats/prestats.mod
@@ -224,10 +224,25 @@ while (( ${#rem} > 0 ))
          
         routine @ getting data from fmriprep directory 
         exec_fsl immv ${intermediate} ${intermediate}_${cur}   
-        imgprt=${img1[sub]%_*_*_*}; conf="_desc-confounds_regressors.tsv"
+
+        # Check if we have a res- tag
+        # Added by recent versions of fmriprep
+        imgname=$(basename ${img1[sub]})
+        conf="_desc-confounds_regressors.tsv"
+        if [[ "$imgname" == *_res-* ]]; then
+           imgprt=${img1[sub]%_*_*_*_*}
+        else
+           imgprt=${img1[sub]%_*_*_*}
+        fi
         exec_sys cp ${imgprt}${conf} $out/prestats/${prefix}_fmriconf.tsv
+
         imgprt2=${img1[sub]%_*_*}; mskpart="_desc-brain_mask.nii.gz"
-        mask1=${imgprt2}${mskpart}; maskpart2=${mask1#*_*_*_*}
+        mask1=${imgprt2}${mskpart};
+        if [[ "$imgname" == *_res-* ]]; then
+           maskpart2=${mask1#*_*_*_*_*}
+        else
+           maskpart2=${mask1#*_*_*_*}
+        fi
         refpart="_boldref.nii.gz"; refvol=${imgprt2}${refpart}
 
         conf2="_desc-confounds_regressors.json"

--- a/modules/task/task.mod
+++ b/modules/task/task.mod
@@ -205,10 +205,24 @@ if (( ${task_fmriprep[cxt]} == 1 ))
         
          routine @ getting data from frmiprep directory 
                   
-        imgprt=${img1[sub]%_*_*_*}; conf="_desc-confounds_regressors.tsv"
+        # Check if we have a res- tag
+        # Added by recent versions of fmriprep
+        imgname=$(basename ${img1[sub]})
+        conf="_desc-confounds_regressors.tsv"
+        if [[ "$imgname" == *_res-* ]]; then
+          imgprt=${img1[sub]%_*_*_*_*}
+        else
+          imgprt=${img1[sub]%_*_*_*}
+        fi
         exec_sys cp ${imgprt}${conf} ${out}/task/${prefix}_fmriconf.tsv
+
         imgprt2=${img1[sub]%_*_*}; mskpart="_desc-brain_mask.nii.gz"
-        mask1=${imgprt2}${mskpart}; maskpart2=${mask1#*_*_*_*}
+        mask1=${imgprt2}${mskpart};
+        if [[ "$imgname" == *_res-* ]]; then
+           maskpart2=${mask1#*_*_*_*_*}
+        else
+           maskpart2=${mask1#*_*_*_*}
+        fi
         refpart="_boldref.nii.gz"; refvol=${imgprt2}${refpart}
          
        output fmriprepconf  ${out}/task/${prefix}_fmriconf.tsv 


### PR DESCRIPTION
fMRIPrep can optionally append `_res-X` tags to filenames, such as `space-MNI152NLin6Asym_res-2_` or `space-MNI152NLin6Asym_res-native_`: https://fmriprep.readthedocs.io/en/20.0.7/spaces.html

This broke the fmriprep file parsing, which was expecting a set number of `_*` tags at the end of the filename, such as here: https://github.com/PennBBL/xcpEngine/blob/39127b744644620a77b34e0320d89996b04e0e98/modules/prestats/prestats.mod#L227

This patch adds a check for the resolution tag, and if so, adds an extra `_*`