### PR TITLE
Typos fixed & example for XCPEngine with SLURM

### DIFF
--- a/docs/containers/index.rst
+++ b/docs/containers/index.rst
@@ -93,10 +93,10 @@ Using SGE to parallelize across subjects
 
 By running xcpEngine from a container, you lose the ability to submit jobs
 to the cluster directly from xcpEngine. Here is a way to split your cohort
-file and submit a qsub job for each line. *Note that we are using
+file and submit a qsub job for each line. Note that we are using
 ``my_cohort_rel_container.csv``, which means we don't need to specify
 an ``-r`` flag. If your cohort file uses paths relative to the host's
-file system you will need to specify ``-r``*::
+file system you will need to specify ``-r``::
 
   #!/bin/bash
   FULL_COHORT=/data/study/my_cohort_rel_container.csv
@@ -138,7 +138,7 @@ You will need to collate group-level outputs after batching subjects with the sc
 
 Using SLURM to parallelize across subjects
 ----------------------------------------
-By running xcpEngine from a container, you lose the ability to submit jobs to the cluster directly from xcpEngine. Here is a way to split your cohort file and submit an sbatch job for each line. *Note that we are using ``my_cohort_rel_host.csv``, which means we need to specify an ``-r`` flag. If your cohort file uses paths relative to the container you dont need to specify ``-r``*.::
+By running xcpEngine from a container, you lose the ability to submit jobs to the cluster directly from xcpEngine. Here is a way to split your cohort file and submit an sbatch job for each line. Note that we are using ``my_cohort_rel_host.csv``, which means we need to specify an ``-r`` flag. If your cohort file uses paths relative to the container you dont need to specify ``-r``.::
 
   #!/bin/bash
   # Adjust these so they work on your system

--- a/docs/containers/index.rst
+++ b/docs/containers/index.rst
@@ -94,9 +94,9 @@ Using SGE to parallelize across subjects
 By running xcpEngine from a container, you lose the ability to submit jobs
 to the cluster directly from xcpEngine. Here is a way to split your cohort
 file and submit a qsub job for each line. *Note that we are using
-`my_cohort_rel_container.csv`, which means we don't need to specify
-an `-r` flag. If your cohort file uses paths relative to the host's
-file system you will need to specify `-r`*::
+``my_cohort_rel_container.csv`, which means we don't need to specify
+an ``-r`` flag. If your cohort file uses paths relative to the host's
+file system you will need to specify ``-r``::
 
   #!/bin/bash
   FULL_COHORT=/data/study/my_cohort_rel_container.csv
@@ -138,7 +138,7 @@ You will need to collate group-level outputs after batching subjects with the sc
 
 Using SLURM to parallelize across subjects
 ----------------------------------------
-By running xcpEngine from a container, you lose the ability to submit jobs to the cluster directly from xcpEngine. Here is a way to split your cohort file and submit an sbatch job for each line. Note that we are using `my_cohort_rel_host.csv`, which means we need to specify an `-r` flag. If your cohort file uses paths relative to the container you dont need to specify `-r`.::
+By running xcpEngine from a container, you lose the ability to submit jobs to the cluster directly from xcpEngine. Here is a way to split your cohort file and submit an sbatch job for each line. Note that we are using `my_cohort_rel_host.csv`, which means we need to specify an ``-r`` flag. If your cohort file uses paths relative to the container you dont need to specify ``-r``.::
 
   #!/bin/bash
   # Adjust these so they work on your system

--- a/docs/containers/index.rst
+++ b/docs/containers/index.rst
@@ -10,10 +10,10 @@ xcpEngine Docker/Singularity image. **These instructions are not needed
 if you are using ``xcpengine-docker`` or ``xcpengine-singularity``.
 They are here in case you need to run them manually**
 
-.. _singularity:
+.. _singularity_:
 
 
-Using xcpEngine with Singularity
+Using xcpEngine with Singularity_
 ---------------------------------
 
 The easiest way to get started with xcpEngine on a HPC system is
@@ -22,7 +22,7 @@ dockerhub.::
 
   $ singularity build xcpEngine.simg docker://pennbbl/xcpengine:latest
 
-The only potentially tricky part about using a singularity image
+The only potentially tricky part about using a singularity_ image
 is the need to *bind* directories from your host operating system
 so they can be accessed from inside the container. Suppose there
 is a ``/data`` directory that is shared across your cluster as
@@ -60,7 +60,7 @@ you run the container.::
 Where the paths in ``my_cohort_host_paths.csv`` all start with
 ``/data``.
 
-**NOTE:** Singularity typically mounts the host's ``/tmp`` as
+**NOTE:** Singularity_ typically mounts the host's ``/tmp`` as
 ``/tmp`` in the container. This is useful in the case where you
 are running xcpEngine using a queueing system and want to write
 intermediate files to the locally-mounted scratch space provided
@@ -68,10 +68,10 @@ in a ``$TMPDIR`` variable specific to the job. If you want to use
 a different temporary directory, be sure that it's accessible from
 inside the container and provide the container-bound path to it.
 
-Using xcpEngine with Docker
+Using xcpEngine with Docker_
 -----------------------------
 
-Using Docker is almost identical to Singularity, with the ``-B`` arguments
+Using Docker_ is almost identical to Singularity, with the ``-B`` arguments
 substituted for ``-v``. Here is an example:::
 
   $ docker --rm -it \
@@ -83,7 +83,7 @@ substituted for ``-v``. Here is an example:::
       -o /data/study/output \
       -i $TMPDIR
 
-Mounting directories in Docker is easier than with Singularity.
+Mounting directories in Docker_ is easier than with Singularity_.
 
 
 Using SGE to parallelize across subjects

--- a/docs/containers/index.rst
+++ b/docs/containers/index.rst
@@ -138,11 +138,11 @@ You will need to collate group-level outputs after batching subjects with the sc
 
 Using SLURM to parallelize across subjects
 ----------------------------------------
-By running xcpEngine from a container, you lose the ability to submit jobs to the cluster directly from xcpEngine. Here is a way to split your cohort file and submit a qsub job for each line. Note that we are using `my_cohort_rel_container.csv`, which means we don't need to specify an `-r` flag. If your cohort file uses paths relative to the host's file system you will need to specify `-r`. In case you use SLURM make sure your design-files are not including any SGE specific inputs::
+By running xcpEngine from a container, you lose the ability to submit jobs to the cluster directly from xcpEngine. Here is a way to split your cohort file and submit a qsub job for each line. Note that we are using `my_cohort_rel_host.csv`, which means we need to specify an `-r` flag. If your cohort file uses paths relative to the container you dont need to specify `-r`.::
 
   #!/bin/bash
   # Adjust these so they work on your system
-  FULL_COHORT=/data/study/my_cohort_rel_container.csv
+  FULL_COHORT=/data/study/my_cohort_rel_host.csv
   NJOBS=`wc -l < ${FULL_COHORT}`
   HEADER="$(head -n 1 $FULL_COHORT)"
   SIMG=/data/containers/xcpEngine.simg

--- a/docs/containers/index.rst
+++ b/docs/containers/index.rst
@@ -138,6 +138,7 @@ You will need to collate group-level outputs after batching subjects with the sc
 
 Using SLURM to parallelize across subjects
 ----------------------------------------
+::
 
 #!/bin/bash
 # Adjust these so they work on your system

--- a/docs/containers/index.rst
+++ b/docs/containers/index.rst
@@ -68,6 +68,8 @@ in a ``$TMPDIR`` variable specific to the job. If you want to use
 a different temporary directory, be sure that it's accessible from
 inside the container and provide the container-bound path to it.
 
+.. _Docker:
+
 Using xcpEngine with Docker_
 -----------------------------
 

--- a/docs/containers/index.rst
+++ b/docs/containers/index.rst
@@ -140,47 +140,47 @@ Using SLURM to parallelize across subjects
 ----------------------------------------
 ::
 
-#!/bin/bash
-# Adjust these so they work on your system
-FULL_COHORT=/data/study/my_cohort_rel_container.csv
-NJOBS=`wc -l < ${FULL_COHORT}`
-HEADER="$(head -n 1 $FULL_COHORT)"
-SIMG=/data/containers/xcpEngine.simg
-# memory, CPU and time depend on the designfile and your dataset. Adjust values correspondingly
-XCP_MEM=0G
-XCP_C=0
-XCP_TIME=0:0:0
+  #!/bin/bash
+  # Adjust these so they work on your system
+  FULL_COHORT=/data/study/my_cohort_rel_container.csv
+  NJOBS=`wc -l < ${FULL_COHORT}`
+  HEADER="$(head -n 1 $FULL_COHORT)"
+  SIMG=/data/containers/xcpEngine.simg
+  # memory, CPU and time depend on the designfile and your dataset. Adjust values correspondingly
+  XCP_MEM=0G
+  XCP_C=0
+  XCP_TIME=0:0:0
 
-if [[ ${NJOBS} == 0 ]]; then
-    exit 0
-fi
+  if [[ ${NJOBS} == 0 ]]; then
+      exit 0
+  fi
 
-cat << EOF > xcpParallel.sh
-#!/bin/bash -l
-#SBATCH --array 1-${NJOBS}
-#SBATCH --job-name xcp_engine
-#SBATCH --mem $XCP_MEM
-#SBATCH -c $XCP_C
-#SBATCH --time $XCP_TIME
-#SBATCH --workdir /my_working_directory
-#SBATCH --output /my_working_directory/logs/slurm-%A_%a.out
+  cat << EOF > xcpParallel.sh
+  #!/bin/bash -l
+  #SBATCH --array 1-${NJOBS}
+  #SBATCH --job-name xcp_engine
+  #SBATCH --mem $XCP_MEM
+  #SBATCH -c $XCP_C
+  #SBATCH --time $XCP_TIME
+  #SBATCH --workdir /my_working_directory
+  #SBATCH --output /my_working_directory/logs/slurm-%A_%a.out
 
 
-LINE_NUM=\$( expr \$SLURM_ARRAY_TASK_ID + 1 )
-LINE=\$(awk "NR==\$LINE_NUM" $FULL_COHORT)
-TEMP_COHORT=${FULL_COHORT}.\${SLURM_ARRAY_TASK_ID}.csv
-echo $HEADER > \$TEMP_COHORT
-echo \$LINE >> \$TEMP_COHORT 
+  LINE_NUM=\$( expr \$SLURM_ARRAY_TASK_ID + 1 )
+  LINE=\$(awk "NR==\$LINE_NUM" $FULL_COHORT)
+  TEMP_COHORT=${FULL_COHORT}.\${SLURM_ARRAY_TASK_ID}.csv
+  echo $HEADER > \$TEMP_COHORT
+  echo \$LINE >> \$TEMP_COHORT 
 
-singularity run -B /home/user/data:/data $SIMG \\
-  -d /home/user/data/study/my_design.dsn \\
-  -c /home/user\${TEMP_COHORT} \\
-  -o /home/user/data/study/output \\
-  -r /data \\
-  -i \$TMPDIR
+  singularity run -B /home/user/data:/data $SIMG \\
+    -d /home/user/data/study/my_design.dsn \\
+    -c /home/user\${TEMP_COHORT} \\
+    -o /home/user/data/study/output \\
+    -r /data \\
+    -i \$TMPDIR
 
-EOF
-sbatch xcpParallel.sh
+  EOF
+  sbatch xcpParallel.sh
 
 
 Using the bundled software

--- a/docs/containers/index.rst
+++ b/docs/containers/index.rst
@@ -13,7 +13,7 @@ They are here in case you need to run them manually**
 .. _singularity:
 
 
-Using xcpEngine with Singularity
+Using xcpEngine with Singularity_
 ---------------------------------
 
 The easiest way to get started with xcpEngine on a HPC system is
@@ -60,7 +60,7 @@ you run the container.::
 Where the paths in ``my_cohort_host_paths.csv`` all start with
 ``/data``.
 
-**NOTE:** Singularity typically mounts the host's ``/tmp`` as
+**NOTE:** Singularity_ typically mounts the host's ``/tmp`` as
 ``/tmp`` in the container. This is useful in the case where you
 are running xcpEngine using a queueing system and want to write
 intermediate files to the locally-mounted scratch space provided
@@ -68,10 +68,10 @@ in a ``$TMPDIR`` variable specific to the job. If you want to use
 a different temporary directory, be sure that it's accessible from
 inside the container and provide the container-bound path to it.
 
-Using xcpEngine with Docker
+Using xcpEngine with Docker_
 -----------------------------
 
-Using Docker is almost identical to Singularity, with the ``-B`` arguments
+Using Docker_ is almost identical to Singularity_, with the ``-B`` arguments
 substituted for ``-v``. Here is an example:::
 
   $ docker --rm -it \

--- a/docs/containers/index.rst
+++ b/docs/containers/index.rst
@@ -138,7 +138,7 @@ You will need to collate group-level outputs after batching subjects with the sc
 
 Using SLURM to parallelize across subjects
 ----------------------------------------
-By running xcpEngine from a container, you lose the ability to submit jobs to the cluster directly from xcpEngine. Here is a way to split your cohort file and submit a qsub job for each line. Note that we are using `my_cohort_rel_host.csv`, which means we need to specify an `-r` flag. If your cohort file uses paths relative to the container you dont need to specify `-r`.::
+By running xcpEngine from a container, you lose the ability to submit jobs to the cluster directly from xcpEngine. Here is a way to split your cohort file and submit a sbatch job for each line. Note that we are using `my_cohort_rel_host.csv`, which means we need to specify an `-r` flag. If your cohort file uses paths relative to the container you dont need to specify `-r`.::
 
   #!/bin/bash
   # Adjust these so they work on your system

--- a/docs/containers/index.rst
+++ b/docs/containers/index.rst
@@ -138,7 +138,7 @@ You will need to collate group-level outputs after batching subjects with the sc
 
 Using SLURM to parallelize across subjects
 ----------------------------------------
-By running xcpEngine from a container, you lose the ability to submit jobs to the cluster directly from xcpEngine. Here is a way to split your cohort file. Note that we are using `my_cohort_rel_host.csv`, which means we need to specify an `-r` flag. If your cohort file uses paths relative to the container you dont need to specify `-r`.::
+By running xcpEngine from a container, you lose the ability to submit jobs to the cluster directly from xcpEngine. Here is a way to split your cohort file and submit a qsub job for each line. Note that we are using `my_cohort_rel_host.csv`, which means we need to specify an `-r` flag. If your cohort file uses paths relative to the container you dont need to specify `-r`.::
 
   #!/bin/bash
   # Adjust these so they work on your system

--- a/docs/containers/index.rst
+++ b/docs/containers/index.rst
@@ -94,9 +94,9 @@ Using SGE to parallelize across subjects
 By running xcpEngine from a container, you lose the ability to submit jobs
 to the cluster directly from xcpEngine. Here is a way to split your cohort
 file and submit a qsub job for each line. *Note that we are using
-``my_cohort_rel_container.csv`, which means we don't need to specify
+``my_cohort_rel_container.csv``, which means we don't need to specify
 an ``-r`` flag. If your cohort file uses paths relative to the host's
-file system you will need to specify ``-r``::
+file system you will need to specify ``-r``*::
 
   #!/bin/bash
   FULL_COHORT=/data/study/my_cohort_rel_container.csv
@@ -138,7 +138,7 @@ You will need to collate group-level outputs after batching subjects with the sc
 
 Using SLURM to parallelize across subjects
 ----------------------------------------
-By running xcpEngine from a container, you lose the ability to submit jobs to the cluster directly from xcpEngine. Here is a way to split your cohort file and submit an sbatch job for each line. Note that we are using `my_cohort_rel_host.csv`, which means we need to specify an ``-r`` flag. If your cohort file uses paths relative to the container you dont need to specify ``-r``.::
+By running xcpEngine from a container, you lose the ability to submit jobs to the cluster directly from xcpEngine. Here is a way to split your cohort file and submit an sbatch job for each line. *Note that we are using ``my_cohort_rel_host.csv``, which means we need to specify an ``-r`` flag. If your cohort file uses paths relative to the container you dont need to specify ``-r``*.::
 
   #!/bin/bash
   # Adjust these so they work on your system

--- a/docs/containers/index.rst
+++ b/docs/containers/index.rst
@@ -138,7 +138,7 @@ You will need to collate group-level outputs after batching subjects with the sc
 
 Using SLURM to parallelize across subjects
 ----------------------------------------
-By running xcpEngine from a container, you lose the ability to submit jobs to the cluster directly from xcpEngine. Here is a way to split your cohort file and submit a sbatch job for each line. Note that we are using `my_cohort_rel_host.csv`, which means we need to specify an `-r` flag. If your cohort file uses paths relative to the container you dont need to specify `-r`.::
+By running xcpEngine from a container, you lose the ability to submit jobs to the cluster directly from xcpEngine. Here is a way to split your cohort file and submit a sbatch job for each line. Note that we are using `my_cohort_rel_host.csv`, which means we need to specify an `-r` flag. If your cohort file uses paths relative to the container you dont need to specify `-r`*.::
 
   #!/bin/bash
   # Adjust these so they work on your system

--- a/docs/containers/index.rst
+++ b/docs/containers/index.rst
@@ -138,7 +138,7 @@ You will need to collate group-level outputs after batching subjects with the sc
 
 Using SLURM to parallelize across subjects
 ----------------------------------------
-By running xcpEngine from a container, you lose the ability to submit jobs to the cluster directly from xcpEngine. Here is a way to split your cohort file and submit a qsub job for each line. Note that we are using `my_cohort_rel_host.csv`, which means we need to specify an `-r` flag. If your cohort file uses paths relative to the container you dont need to specify `-r`.::
+By running xcpEngine from a container, you lose the ability to submit jobs to the cluster directly from xcpEngine. Here is a way to split your cohort file. Note that we are using `my_cohort_rel_host.csv`, which means we need to specify an `-r` flag. If your cohort file uses paths relative to the container you dont need to specify `-r`.::
 
   #!/bin/bash
   # Adjust these so they work on your system

--- a/docs/containers/index.rst
+++ b/docs/containers/index.rst
@@ -10,10 +10,10 @@ xcpEngine Docker/Singularity image. **These instructions are not needed
 if you are using ``xcpengine-docker`` or ``xcpengine-singularity``.
 They are here in case you need to run them manually**
 
-.. _singularity_:
+.. _singularity:
 
 
-Using xcpEngine with Singularity_
+Using xcpEngine with Singularity
 ---------------------------------
 
 The easiest way to get started with xcpEngine on a HPC system is
@@ -22,7 +22,7 @@ dockerhub.::
 
   $ singularity build xcpEngine.simg docker://pennbbl/xcpengine:latest
 
-The only potentially tricky part about using a singularity_ image
+The only potentially tricky part about using a singularity image
 is the need to *bind* directories from your host operating system
 so they can be accessed from inside the container. Suppose there
 is a ``/data`` directory that is shared across your cluster as
@@ -60,7 +60,7 @@ you run the container.::
 Where the paths in ``my_cohort_host_paths.csv`` all start with
 ``/data``.
 
-**NOTE:** Singularity_ typically mounts the host's ``/tmp`` as
+**NOTE:** Singularity typically mounts the host's ``/tmp`` as
 ``/tmp`` in the container. This is useful in the case where you
 are running xcpEngine using a queueing system and want to write
 intermediate files to the locally-mounted scratch space provided
@@ -68,10 +68,10 @@ in a ``$TMPDIR`` variable specific to the job. If you want to use
 a different temporary directory, be sure that it's accessible from
 inside the container and provide the container-bound path to it.
 
-Using xcpEngine with Docker_
+Using xcpEngine with Docker
 -----------------------------
 
-Using Docker_ is almost identical to Singularity, with the ``-B`` arguments
+Using Docker is almost identical to Singularity, with the ``-B`` arguments
 substituted for ``-v``. Here is an example:::
 
   $ docker --rm -it \
@@ -83,7 +83,7 @@ substituted for ``-v``. Here is an example:::
       -o /data/study/output \
       -i $TMPDIR
 
-Mounting directories in Docker_ is easier than with Singularity_.
+Mounting directories in Docker is easier than with Singularity.
 
 
 Using SGE to parallelize across subjects

--- a/docs/containers/index.rst
+++ b/docs/containers/index.rst
@@ -138,7 +138,7 @@ You will need to collate group-level outputs after batching subjects with the sc
 
 Using SLURM to parallelize across subjects
 ----------------------------------------
-::
+By running xcpEngine from a container, you lose the ability to submit jobs to the cluster directly from xcpEngine. Here is a way to split your cohort file and submit a qsub job for each line. Note that we are using `my_cohort_rel_container.csv`, which means we don't need to specify an `-r` flag. If your cohort file uses paths relative to the host's file system you will need to specify `-r`. In case you use SLURM make sure your design-files are not including any SGE specific inputs::
 
   #!/bin/bash
   # Adjust these so they work on your system

--- a/docs/containers/index.rst
+++ b/docs/containers/index.rst
@@ -135,6 +135,53 @@ file system you will need to specify `-r`*::
 
 You will need to collate group-level outputs after batching subjects with the script ``${XCPEDIR}/utils/combineOutput`` script, provided in ``utils``.
 
+
+Using SLURM to parallelize across subjects
+----------------------------------------
+
+#!/bin/bash
+# Adjust these so they work on your system
+FULL_COHORT=/data/study/my_cohort_rel_container.csv
+NJOBS=`wc -l < ${FULL_COHORT}`
+HEADER="$(head -n 1 $FULL_COHORT)"
+SIMG=/data/containers/xcpEngine.simg
+# memory, CPU and time depend on the designfile and your dataset. Adjust values correspondingly
+XCP_MEM=0G
+XCP_C=0
+XCP_TIME=0:0:0
+
+if [[ ${NJOBS} == 0 ]]; then
+    exit 0
+fi
+
+cat << EOF > xcpParallel.sh
+#!/bin/bash -l
+#SBATCH --array 1-${NJOBS}
+#SBATCH --job-name xcp_engine
+#SBATCH --mem $XCP_MEM
+#SBATCH -c $XCP_C
+#SBATCH --time $XCP_TIME
+#SBATCH --workdir /my_working_directory
+#SBATCH --output /my_working_directory/logs/slurm-%A_%a.out
+
+
+LINE_NUM=\$( expr \$SLURM_ARRAY_TASK_ID + 1 )
+LINE=\$(awk "NR==\$LINE_NUM" $FULL_COHORT)
+TEMP_COHORT=${FULL_COHORT}.\${SLURM_ARRAY_TASK_ID}.csv
+echo $HEADER > \$TEMP_COHORT
+echo \$LINE >> \$TEMP_COHORT 
+
+singularity run -B /home/user/data:/data $SIMG \\
+  -d /home/user/data/study/my_design.dsn \\
+  -c /home/user\${TEMP_COHORT} \\
+  -o /home/user/data/study/output \\
+  -r /data \\
+  -i \$TMPDIR
+
+EOF
+sbatch xcpParallel.sh
+
+
 Using the bundled software
 ----------------------------
 

--- a/docs/containers/index.rst
+++ b/docs/containers/index.rst
@@ -13,11 +13,11 @@ They are here in case you need to run them manually**
 .. _singularity:
 
 
-Using xcpEngine with Singularity_
+Using xcpEngine with Singularity
 ---------------------------------
 
 The easiest way to get started with xcpEngine on a HPC system is
-to build a Singularity_ image from the xcpEngine released on
+to build a Singularity image from the xcpEngine released on
 dockerhub.::
 
   $ singularity build xcpEngine.simg docker://pennbbl/xcpengine:latest
@@ -60,7 +60,7 @@ you run the container.::
 Where the paths in ``my_cohort_host_paths.csv`` all start with
 ``/data``.
 
-**NOTE:** Singularity_ typically mounts the host's ``/tmp`` as
+**NOTE:** Singularity typically mounts the host's ``/tmp`` as
 ``/tmp`` in the container. This is useful in the case where you
 are running xcpEngine using a queueing system and want to write
 intermediate files to the locally-mounted scratch space provided
@@ -68,10 +68,10 @@ in a ``$TMPDIR`` variable specific to the job. If you want to use
 a different temporary directory, be sure that it's accessible from
 inside the container and provide the container-bound path to it.
 
-Using xcpEngine with Docker_
+Using xcpEngine with Docker
 -----------------------------
 
-Using Docker_ is almost identical to Singularity_, with the ``-B`` arguments
+Using Docker is almost identical to Singularity, with the ``-B`` arguments
 substituted for ``-v``. Here is an example:::
 
   $ docker --rm -it \
@@ -83,7 +83,7 @@ substituted for ``-v``. Here is an example:::
       -o /data/study/output \
       -i $TMPDIR
 
-Mounting directories in Docker_ is easier than with Singularity_.
+Mounting directories in Docker is easier than with Singularity.
 
 
 Using SGE to parallelize across subjects

--- a/docs/containers/index.rst
+++ b/docs/containers/index.rst
@@ -138,7 +138,7 @@ You will need to collate group-level outputs after batching subjects with the sc
 
 Using SLURM to parallelize across subjects
 ----------------------------------------
-By running xcpEngine from a container, you lose the ability to submit jobs to the cluster directly from xcpEngine. Here is a way to split your cohort file and submit a sbatch job for each line. Note that we are using `my_cohort_rel_host.csv`, which means we need to specify an `-r` flag. If your cohort file uses paths relative to the container you dont need to specify `-r`*.::
+By running xcpEngine from a container, you lose the ability to submit jobs to the cluster directly from xcpEngine. Here is a way to split your cohort file and submit an sbatch job for each line. Note that we are using `my_cohort_rel_host.csv`, which means we need to specify an `-r` flag. If your cohort file uses paths relative to the container you dont need to specify `-r`.::
 
   #!/bin/bash
   # Adjust these so they work on your system


### PR DESCRIPTION
Hey PennBBL,
I worked with XCPEngine the last weeks and used SLURM instead of SGE.
Please would you consider pulling from heimbach/xcpEngine into PennBBL/xcpEngine (as you can see I  made changes in docs/containers/index.rst). 
It fixes the following things:
1) typos and formation mistakes 
- Docker_
- `-r` flag
- Singularity_ 
2) added a section with an example on how to run XCPEngine using SLURM.

Thanks a lot! Best regards


