### PR TITLE
Fixed ".:", remove redundancy and added helpful reminder

### DIFF
--- a/docs/containers/index.rst
+++ b/docs/containers/index.rst
@@ -125,8 +125,8 @@ file system you will need to specify ``-r``::
 
   \$SNGL run -B /data:/home/user/data \$SIMG \\
     -c /home/user\${TEMP_COHORT} \\
-    -d /data/study/my_design.dsn \\
-    -o /data/study/output \\
+    -d /home/user/data/study/my_design.dsn \\
+    -o /home/user/data/study/output \\
     -i \$TMPDIR
 
   EOF

--- a/docs/containers/index.rst
+++ b/docs/containers/index.rst
@@ -183,7 +183,7 @@ By running xcpEngine from a container, you lose the ability to submit jobs to th
   EOF
   sbatch xcpParallel.sh
 
-Keep in mind that - next to the directories and settings you need to adjust as mentioned above - the ``logs`` directory needs to exist in your working-directory ( ``/my_working_directory/logs`` ) and you need to define the ``$TMPDIR``. 
+Keep in mind that - next to the directories and settings you need to adjust as mentioned above - the ``logs`` directory needs to exist in your working-directory (see ``/my_working_directory/logs`` ) and you need to define the ``TMPDIR``variable (see ``$TMPDIR``). 
 
 Using the bundled software
 ----------------------------

--- a/docs/containers/index.rst
+++ b/docs/containers/index.rst
@@ -124,7 +124,7 @@ file system you will need to specify ``-r``::
   echo \$LINE >> \$TEMP_COHORT
 
   \$SNGL run -B /data:/home/user/data \$SIMG \\
-    -c /home/user\${TEMP_COHORT} \\
+    -c \${TEMP_COHORT} \\
     -d /home/user/data/study/my_design.dsn \\
     -o /home/user/data/study/output \\
     -i \$TMPDIR

--- a/docs/containers/index.rst
+++ b/docs/containers/index.rst
@@ -125,8 +125,8 @@ file system you will need to specify ``-r``::
 
   \$SNGL run -B /data:/home/user/data \$SIMG \\
     -c \${TEMP_COHORT} \\
-    -d /home/user/data/study/my_design.dsn \\
-    -o /home/user/data/study/output \\
+    -d /data/study/my_design.dsn \\
+    -o /data/study/output \\
     -i \$TMPDIR
 
   EOF
@@ -175,7 +175,7 @@ By running xcpEngine from a container, you lose the ability to submit jobs to th
 
   singularity run -B /home/user/data:/data $SIMG \\
     -d /data/study/my_design.dsn \\
-    -c /home/user\${TEMP_COHORT} \\
+    -c \${TEMP_COHORT} \\
     -o /data/study/output \\
     -r /data \\
     -i \$TMPDIR

--- a/docs/containers/index.rst
+++ b/docs/containers/index.rst
@@ -183,7 +183,7 @@ By running xcpEngine from a container, you lose the ability to submit jobs to th
   EOF
   sbatch xcpParallel.sh
 
-Keep in mind that - next to the directories and settings you need to adjust as mentioned above - the ``logs`` directory needs to exist in your working-directory (see ``/my_working_directory/logs`` ) and you need to define the ``TMPDIR``variable (see ``$TMPDIR``). 
+Keep in mind that - next to the directories and settings you need to adjust as mentioned above - the ``logs`` directory needs to exist in your working-directory (see ``/my_working_directory/logs`` ) and you need to define the ``TMPDIR`` variable (see ``$TMPDIR``). 
 
 Using the bundled software
 ----------------------------

--- a/docs/containers/index.rst
+++ b/docs/containers/index.rst
@@ -183,6 +183,7 @@ By running xcpEngine from a container, you lose the ability to submit jobs to th
   EOF
   sbatch xcpParallel.sh
 
+Keep in mind that - next to the directories and settings you need to adjust as mentioned above - the ``logs`` directory needs to exist in your working-directory ( ``/my_working_directory/logs`` ) and you need to define the ``$TMPDIR``. 
 
 Using the bundled software
 ----------------------------

--- a/docs/containers/index.rst
+++ b/docs/containers/index.rst
@@ -183,7 +183,7 @@ By running xcpEngine from a container, you lose the ability to submit jobs to th
   EOF
   sbatch xcpParallel.sh
 
-Keep in mind that - next to the directories and settings you need to adjust as mentioned above - the ``logs`` directory needs to exist in your working-directory (see ``/my_working_directory/logs`` ) and you need to define the ``TMPDIR`` variable (see ``$TMPDIR``). 
+Keep in mind that - next to the directories and settings you need to adjust as mentioned in the script above - the ``logs`` directory needs to exist in your working-directory (see ``/my_working_directory/logs`` ) and you need to define the ``TMPDIR`` variable (see ``$TMPDIR``). 
 
 Using the bundled software
 ----------------------------

--- a/docs/containers/index.rst
+++ b/docs/containers/index.rst
@@ -138,7 +138,8 @@ You will need to collate group-level outputs after batching subjects with the sc
 
 Using SLURM to parallelize across subjects
 ----------------------------------------
-By running xcpEngine from a container, you lose the ability to submit jobs to the cluster directly from xcpEngine. Here is a way to split your cohort file and submit an sbatch job for each line. Note that we are using ``my_cohort_rel_host.csv``, which means we need to specify an ``-r`` flag. If your cohort file uses paths relative to the container you dont need to specify ``-r``.::
+By running xcpEngine from a container, you lose the ability to submit jobs to the cluster directly from xcpEngine. Here is a way to split your cohort file and submit an sbatch job for each line. Note that we are using ``my_cohort_rel_host.csv``, which means we need to specify an ``-r`` flag. If your cohort file uses paths relative to the container you dont need to specify ``-r``.
+::
 
   #!/bin/bash
   # Adjust these so they work on your system

--- a/docs/containers/index.rst
+++ b/docs/containers/index.rst
@@ -124,7 +124,7 @@ file system you will need to specify ``-r``::
   echo \$LINE >> \$TEMP_COHORT
 
   \$SNGL run -B /data:/home/user/data \$SIMG \\
-    -c \${TEMP_COHORT} \\
+    -c /home/user\${TEMP_COHORT} \\
     -d /data/study/my_design.dsn \\
     -o /data/study/output \\
     -i \$TMPDIR

--- a/docs/containers/index.rst
+++ b/docs/containers/index.rst
@@ -173,9 +173,9 @@ By running xcpEngine from a container, you lose the ability to submit jobs to th
   echo \$LINE >> \$TEMP_COHORT 
 
   singularity run -B /home/user/data:/data $SIMG \\
-    -d /home/user/data/study/my_design.dsn \\
+    -d /data/study/my_design.dsn \\
     -c /home/user\${TEMP_COHORT} \\
-    -o /home/user/data/study/output \\
+    -o /data/study/output \\
     -r /data \\
     -i \$TMPDIR
 


### PR DESCRIPTION
Dear PennBBL,
please consider accepting my second pull request. Here is what it does:
1) I fixed my typo with ".:"  by moving the "::" into the next line (so it only the "." is visible now). 
2) I removed redundancy in my script ( `-B /home/user/data:/data` is set before so instead of `/home/user/data` the use of `/data` after the bind is enough) 
3) I added the helpful reminder (for beginners like me) that reminds people to create the `logs` directory in there working directory (`/my_working_directory/logs) and to define `TMPDIR` (`$TMPDIR) in order to make the script work
