### PR TITLE
Changed structure of "parallelize"-part 

### DIFF
--- a/docs/containers/index.rst
+++ b/docs/containers/index.rst
@@ -201,9 +201,7 @@ Using SLURM_ to parallelize across subjects
 
 NOTE
 
-Depending on your design-file some modules refer by default to ``qsub`` (SGE_) which doenst exist in your container once you use ``SBATCH`` (SLURM_). The ``jfl`` module used for example in the 
- [anat-antsct.dsn](xcpEngine/designs/anat-antsct.dsn)  
-has this setting ``jlf_parallel[3]=1``. The ``1`` refers to ``qsub`` here. Using ``SBATCH`` you have to change that setting. ``jlf_parallel[3]=0`` will solve the problem but will increase processing time significantly (you dont process parallel anymore but serial then). 
+Depending on your design-file some modules refer by default to ``qsub`` (SGE_) which doenst exist in your container once you use ``SBATCH`` (SLURM_). The ``jfl`` module used for example in the [anat-antsct.dsn](xcpEngine/designs/anat-antsct.dsn) has this setting ``jlf_parallel[3]=1``. The ``1`` refers to ``qsub`` here. Using ``SBATCH`` you have to change that setting. ``jlf_parallel[3]=0`` will solve the problem but will increase processing time significantly (you dont process parallel anymore but serial then). 
 by default (built into the container?) antsJointLabelFusion.sh is trying to use SGE qsub -c 1 Option and that fails because there is no qsub in the container 
 
 

--- a/docs/containers/index.rst
+++ b/docs/containers/index.rst
@@ -197,7 +197,7 @@ Using SLURM_ to parallelize across subjects
   EOF
   sbatch xcpParallel.sh
 
-Keep in mind that - next to the directories and settings you need to adjust in the beginning of the script as mentioned above - the ``path/to/your/working_directory`` needs to be defined and the ``logs`` directory needs to exist in your working-directory (see ``--workdir /path/to/your/working_directory`` and ``--output /path/to/your/working_directory/logs/slurm-%A_%a.out`` ). Furthermore ``/home/user/data`` needs to be adjusted to your system (see ``-B /home/user/data:/data``).
+Keep in mind that - next to the directories and settings you need to adjust in the beginning of the script as mentioned above - the ``/path/to/your/working_directory`` needs to be defined and the ``logs`` directory needs to exist in your working-directory (see ``--workdir /path/to/your/working_directory`` and ``--output /path/to/your/working_directory/logs/slurm-%A_%a.out`` ). Furthermore ``/home/user/data`` needs to be adjusted to your system (see ``-B /home/user/data:/data``).
 
 NOTE
 

--- a/docs/containers/index.rst
+++ b/docs/containers/index.rst
@@ -89,7 +89,7 @@ Mounting directories in Docker is easier than with Singularity.
 
 
 Parallelize across subjects
-----------------------------------------
+=================================
 
 By running xcpEngine from a container, you lose the ability to submit jobs
 to the cluster directly from xcpEngine. We provide two examplary ways to split your cohort
@@ -104,7 +104,7 @@ with the ``${XCPEDIR}/utils/combineOutput`` script, provided in ``utils``.
 .. _SGE:
 
 Using SGE_ to parallelize across subjects
-----------------------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 ::
 
@@ -148,7 +148,7 @@ Using SGE_ to parallelize across subjects
 .. _SLURM:
 
 Using SLURM_ to parallelize across subjects
-----------------------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 ::
 

--- a/docs/containers/index.rst
+++ b/docs/containers/index.rst
@@ -202,7 +202,7 @@ Using SLURM_ to parallelize across subjects
 NOTE
 
 Depending on your design-file some modules refer by default to ``qsub`` (SGE_) which doenst exist in your container once you use ``SBATCH`` (SLURM_). The ``jfl`` module used for example in the 
- [anat-antsct.dsn](https://github.com/PennBBL/xcpEngine/blob/master/designs/anat-antsct.dsn)  
+ [anat-antsct.dsn](xcpEngine/designs/anat-antsct.dsn)  
 has this setting ``jlf_parallel[3]=1``. The ``1`` refers to ``qsub`` here. Using ``SBATCH`` you have to change that setting. ``jlf_parallel[3]=0`` will solve the problem but will increase processing time significantly (you dont process parallel anymore but serial then). 
 by default (built into the container?) antsJointLabelFusion.sh is trying to use SGE qsub -c 1 Option and that fails because there is no qsub in the container 
 

--- a/docs/containers/index.rst
+++ b/docs/containers/index.rst
@@ -201,7 +201,7 @@ Using SLURM_ to parallelize across subjects
 
 NOTE
 
-Depending on your design-file some modules refer by default to ``qsub`` (SGE_) which doenst exist in your container once you use ``SBATCH`` (SLURM_). The `_jfl <https://xcpengine.readthedocs.io/modules/jlf.html#jlf>`_ module used for example in the `anat-antsct <https://github.com/PennBBL/xcpEngine/blob/master/designs/anat-antsct.dsn>`_ has this setting ``jlf_parallel[3]=1``. The ``1`` refers to ``qsub`` here. Using ``SBATCH`` you have to change that setting: ``jlf_parallel[3]=0`` will solve the problem but will increase processing time significantly (you dont process parallel anymore but serial then). 
+Depending on your design-file some modules refer by default to ``qsub`` (SGE_) which doenst exist in your container once you use ``SBATCH`` (SLURM_). The `jfl <https://xcpengine.readthedocs.io/modules/jlf.html#jlf>`_ module used for example in the `anat-antsct <https://github.com/PennBBL/xcpEngine/blob/master/designs/anat-antsct.dsn>`_ has this setting ``jlf_parallel[3]=1``. The ``1`` refers to ``qsub`` here. Using ``SBATCH`` you have to change that setting: ``jlf_parallel[3]=0`` will solve the problem but will increase processing time significantly (you dont process parallel anymore but serial then). 
 
 
 

--- a/docs/containers/index.rst
+++ b/docs/containers/index.rst
@@ -94,10 +94,10 @@ Parallelize across subjects
 By running xcpEngine from a container, you lose the ability to submit jobs
 to the cluster directly from xcpEngine. We provide two examplary ways to split your cohort
 file and submit either a ``qsub`` (SGE_) or an ``sbatch`` (SLURM_)  -job for each line. 
-For illustrating reasons the two different scripts refer to different cohort-file-types: The SGE 
-script uses a ``my_cohort_rel_container.csv`` cohortfile, which means we **don't need** to 
-specify an ``-r`` flag. The SLURM script uses a ``my_cohort_rel_host.csv`` cohortfile, which 
-means we **need** to specify an ``-r`` flag.
+For illustrating reasons the two different scripts refer to different cohort-file-types: If
+you use a ``my_cohort_rel_container.csv`` cohortfile you **don't need** to specify an
+``-r`` flag (like in the SGE script). If you use a ``my_cohort_rel_host.csv`` cohortfile you
+**need** to specify an ``-r`` flag (like in the SLURM script).
 Note for both scripts: You will need to collate group-level outputs after batching subjects
 with the ``${XCPEDIR}/utils/combineOutput`` script, provided in ``utils``.
 

--- a/docs/containers/index.rst
+++ b/docs/containers/index.rst
@@ -201,7 +201,7 @@ Using SLURM_ to parallelize across subjects
 
 NOTE
 
-Depending on your design-file some modules refer by default to ``qsub`` (SGE_) which doenst exist in your container once you use ``SBATCH`` (SLURM_). The ``jfl`` module used for example in the ``anat-antsct.dsn``(https://github.com/PennBBL/xcpEngine/blob/master/designs/anat-antsct.dsn) has this setting ``jlf_parallel[3]=1``. The ``1`` refers to ``qsub`` here. Using ``SBATCH`` you have to change that setting. ``jlf_parallel[3]=0`` will solve the problem but will increase processing time significantly (you dont process parallel anymore but serial then). 
+Depending on your design-file some modules refer by default to ``qsub`` (SGE_) which doenst exist in your container once you use ``SBATCH`` (SLURM_). The ``jfl`` module used for example in the ``anat-antsct.dsn`` (https://github.com/PennBBL/xcpEngine/blob/master/designs/anat-antsct.dsn) has this setting ``jlf_parallel[3]=1``. The ``1`` refers to ``qsub`` here. Using ``SBATCH`` you have to change that setting. ``jlf_parallel[3]=0`` will solve the problem but will increase processing time significantly (you dont process parallel anymore but serial then). 
 
 
 

--- a/docs/containers/index.rst
+++ b/docs/containers/index.rst
@@ -95,8 +95,8 @@ By running xcpEngine from a container, you lose the ability to submit jobs
 to the cluster directly from xcpEngine. We provide two examplary ways to split your cohort
 file and submit either a ``qsub`` (SGE_) or an ``sbatch`` (SLURM_)  -job for each line. 
 For illustrating reasons the two different scripts refer to different cohort files: The SGE 
-script uses a ``my_cohort_rel_container.csv`` -cohortfile, which means we **don't need** to 
-specify an ``-r`` flag. The SLURM script uses a ``my_cohort_rel_host.csv`` -cohortfile, which 
+script uses a ``my_cohort_rel_container.csv`` cohortfile, which means we **don't need** to 
+specify an ``-r`` flag. The SLURM script uses a ``my_cohort_rel_host.csv`` cohortfile, which 
 means we **need** to specify an ``-r`` flag.
 Note for both scripts: You will need to collate group-level outputs after batching subjects
 with the ``${XCPEDIR}/utils/combineOutput`` script, provided in ``utils``.
@@ -147,7 +147,7 @@ Using SGE_ to parallelize across subjects
 
 .. _SLURM:
 
-Using SLURM to parallelize across subjects
+Using SLURM_ to parallelize across subjects
 ----------------------------------------
 
 ::

--- a/docs/containers/index.rst
+++ b/docs/containers/index.rst
@@ -202,7 +202,9 @@ Using SLURM_ to parallelize across subjects
 NOTE
 
 Depending on your design-file some modules refer by default to ``qsub`` (SGE_) which doenst exist in your container once you use ``SBATCH`` (SLURM_). The ``jfl`` module used for example in the 
+
   [anat-antsct.dsn](https://github.com/PennBBL/xcpEngine/blob/master/designs/anat-antsct.dsn)
+  
 has this setting ``jlf_parallel[3]=1``. The ``1`` refers to ``qsub`` here. Using ``SBATCH`` you have to change that setting. ``jlf_parallel[3]=0`` will solve the problem but will increase processing time significantly (you dont process parallel anymore but serial then). 
 by default (built into the container?) antsJointLabelFusion.sh is trying to use SGE qsub -c 1 Option and that fails because there is no qsub in the container 
 

--- a/docs/containers/index.rst
+++ b/docs/containers/index.rst
@@ -201,7 +201,7 @@ Using SLURM_ to parallelize across subjects
 
 NOTE
 
-Depending on your design-file some modules refer by default to ``qsub`` (SGE_) which doenst exist in your container once you use ``SBATCH`` (SLURM_). The `jfl <https://xcpengine.readthedocs.io/modules/jlf.html#jlf>`_ module used for example in the `anat-antsct <https://github.com/PennBBL/xcpEngine/blob/master/designs/anat-antsct.dsn>`_ has this setting ``jlf_parallel[3]=1``. The ``1`` refers to ``qsub`` here. Using ``SBATCH`` you have to change that setting: ``jlf_parallel[3]=0`` will solve the problem but will increase processing time significantly (you dont process parallel anymore but serial then). 
+Depending on your design-file some modules refer by default to ``qsub`` (SGE_) which doenst exist in your container once you use ``SBATCH`` (SLURM_). The `jfl <https://xcpengine.readthedocs.io/modules/jlf.html#jlf>`_ module  - used for example in the `anat-antsct <https://github.com/PennBBL/xcpEngine/blob/master/designs/anat-antsct.dsn>`_ - has this standard-setting ``jlf_parallel[3]=1``. The ``1`` refers to ``qsub`` here and needs to be changed using ``SBATCH``. ``jlf_parallel[3]=0`` will solve the problem but will increase processing time significantly (since you dont process parallel anymore but serial). 
 
 
 

--- a/docs/containers/index.rst
+++ b/docs/containers/index.rst
@@ -201,7 +201,7 @@ Using SLURM_ to parallelize across subjects
 
 NOTE
 
-Depending on your design-file some modules refer by default to ``qsub`` (SGE_) which doenst exist in your container once you use ``SBATCH`` (SLURM_). The ``jfl`` module used for example in the ``anat-antsct.dsn`` (https://github.com/PennBBL/xcpEngine/blob/master/designs/anat-antsct.dsn) has this setting ``jlf_parallel[3]=1``. The ``1`` refers to ``qsub`` here. Using ``SBATCH`` you have to change that setting. ``jlf_parallel[3]=0`` will solve the problem but will increase processing time significantly (you dont process parallel anymore but serial then). 
+Depending on your design-file some modules refer by default to ``qsub`` (SGE_) which doenst exist in your container once you use ``SBATCH`` (SLURM_). The ``jfl`` module used for example in the ``anat-antsct.dsn`` (https://github.com/PennBBL/xcpEngine/blob/master/designs/anat-antsct.dsn) has this setting ``jlf_parallel[3]=1``. The ``1`` refers to ``qsub`` here. Using ``SBATCH`` you have to change that setting: ``jlf_parallel[3]=0`` will solve the problem but will increase processing time significantly (you dont process parallel anymore but serial then). 
 
 
 

--- a/docs/containers/index.rst
+++ b/docs/containers/index.rst
@@ -197,7 +197,7 @@ Using SLURM_ to parallelize across subjects
   EOF
   sbatch xcpParallel.sh
 
-Keep in mind that - next to the directories and settings you need to adjust in the beginning of the script as mentioned above - the path/to/your/working_directory needs to be defined and the ``logs`` directory needs to exist in your working-directory (see ``--workdir /path/to/your/working_directory`` and ``--output /path/to/your/working_directory/logs`` ). Furthermore ``/home/user/data`` needs to be adjusted to your system (see ``-B /home/user/data:/data``).
+Keep in mind that - next to the directories and settings you need to adjust in the beginning of the script as mentioned above - the ``path/to/your/working_directory`` needs to be defined and the ``logs`` directory needs to exist in your working-directory (see ``--workdir /path/to/your/working_directory`` and ``--output /path/to/your/working_directory/logs/slurm-%A_%a.out`` ). Furthermore ``/home/user/data`` needs to be adjusted to your system (see ``-B /home/user/data:/data``).
 
 NOTE
 

--- a/docs/containers/index.rst
+++ b/docs/containers/index.rst
@@ -201,7 +201,9 @@ Using SLURM_ to parallelize across subjects
 
 NOTE
 
-Depending on your design-file some modules refer by default to ``qsub`` (SGE_) which doenst exist in your container once you use ``SBATCH`` (SLURM_). The ``jfl`` module used for example in the anat-antsct.dsn[https://github.com/PennBBL/xcpEngine/blob/master/designs/anat-antsct.dsn]has this setting ``jlf_parallel[3]=1``. The ``1`` refers to ``qsub`` here. Using ``SBATCH`` you have to change that setting. ``jlf_parallel[3]=0`` will solve the problem but will increase processing time significantly (you dont process parallel anymore but serial then). 
+Depending on your design-file some modules refer by default to ``qsub`` (SGE_) which doenst exist in your container once you use ``SBATCH`` (SLURM_). The ``jfl`` module used for example in the 
+  anat-antsct.dsn[https://github.com/PennBBL/xcpEngine/blob/master/designs/anat-antsct.dsn]
+has this setting ``jlf_parallel[3]=1``. The ``1`` refers to ``qsub`` here. Using ``SBATCH`` you have to change that setting. ``jlf_parallel[3]=0`` will solve the problem but will increase processing time significantly (you dont process parallel anymore but serial then). 
 by default (built into the container?) antsJointLabelFusion.sh is trying to use SGE qsub -c 1 Option and that fails because there is no qsub in the container 
 
 

--- a/docs/containers/index.rst
+++ b/docs/containers/index.rst
@@ -202,9 +202,7 @@ Using SLURM_ to parallelize across subjects
 NOTE
 
 Depending on your design-file some modules refer by default to ``qsub`` (SGE_) which doenst exist in your container once you use ``SBATCH`` (SLURM_). The ``jfl`` module used for example in the 
-
-  [anat-antsct.dsn](https://github.com/PennBBL/xcpEngine/blob/master/designs/anat-antsct.dsn)
-  
+ [anat-antsct.dsn](https://github.com/PennBBL/xcpEngine/blob/master/designs/anat-antsct.dsn)  
 has this setting ``jlf_parallel[3]=1``. The ``1`` refers to ``qsub`` here. Using ``SBATCH`` you have to change that setting. ``jlf_parallel[3]=0`` will solve the problem but will increase processing time significantly (you dont process parallel anymore but serial then). 
 by default (built into the container?) antsJointLabelFusion.sh is trying to use SGE qsub -c 1 Option and that fails because there is no qsub in the container 
 

--- a/docs/containers/index.rst
+++ b/docs/containers/index.rst
@@ -202,7 +202,7 @@ Using SLURM_ to parallelize across subjects
 NOTE
 
 Depending on your design-file some modules refer by default to ``qsub`` (SGE_) which doenst exist in your container once you use ``SBATCH`` (SLURM_). The ``jfl`` module used for example in the 
-  anat-antsct.dsn[https://github.com/PennBBL/xcpEngine/blob/master/designs/anat-antsct.dsn]
+  [anat-antsct.dsn](https://github.com/PennBBL/xcpEngine/blob/master/designs/anat-antsct.dsn)
 has this setting ``jlf_parallel[3]=1``. The ``1`` refers to ``qsub`` here. Using ``SBATCH`` you have to change that setting. ``jlf_parallel[3]=0`` will solve the problem but will increase processing time significantly (you dont process parallel anymore but serial then). 
 by default (built into the container?) antsJointLabelFusion.sh is trying to use SGE qsub -c 1 Option and that fails because there is no qsub in the container 
 

--- a/docs/containers/index.rst
+++ b/docs/containers/index.rst
@@ -153,18 +153,19 @@ Using SLURM_ to parallelize across subjects
 ::
 
   #!/bin/bash
+  
   # Adjust these so they work on your system
   FULL_COHORT=/data/study/my_cohort_rel_host.csv
-  NJOBS=`wc -l < ${FULL_COHORT}`
-  HEADER="$(head -n 1 $FULL_COHORT)"
   SIMG=/data/containers/xcpEngine.simg
   TMPDIR=/path/to/your/tmp-directory
   # memory, CPU and time depend on the designfile and your dataset. Adjust values correspondingly
   XCP_MEM=0G
   XCP_C=0
   XCP_TIME=0:0:0
+  
+  NJOBS=`wc -l < ${FULL_COHORT}`
+  HEADER="$(head -n 1 $FULL_COHORT)"
  
-
   if [[ ${NJOBS} == 0 ]]; then
       exit 0
   fi

--- a/docs/containers/index.rst
+++ b/docs/containers/index.rst
@@ -201,7 +201,7 @@ Using SLURM_ to parallelize across subjects
 
 NOTE
 
-Depending on your design-file some modules refer by default to ``qsub`` (SGE_) which doenst exist in your container once you use ``SBATCH`` (SLURM_). The ``jfl`` module used for example in the ``anat-antsct.dsn`` (https://github.com/PennBBL/xcpEngine/blob/master/designs/anat-antsct.dsn) has this setting ``jlf_parallel[3]=1``. The ``1`` refers to ``qsub`` here. Using ``SBATCH`` you have to change that setting: ``jlf_parallel[3]=0`` will solve the problem but will increase processing time significantly (you dont process parallel anymore but serial then). 
+Depending on your design-file some modules refer by default to ``qsub`` (SGE_) which doenst exist in your container once you use ``SBATCH`` (SLURM_). The `_jfl <https://xcpengine.readthedocs.io/modules/jlf.html#jlf>`_ module used for example in the `anat-antsct <https://github.com/PennBBL/xcpEngine/blob/master/designs/anat-antsct.dsn>`_ has this setting ``jlf_parallel[3]=1``. The ``1`` refers to ``qsub`` here. Using ``SBATCH`` you have to change that setting: ``jlf_parallel[3]=0`` will solve the problem but will increase processing time significantly (you dont process parallel anymore but serial then). 
 
 
 

--- a/docs/containers/index.rst
+++ b/docs/containers/index.rst
@@ -158,11 +158,12 @@ Using SLURM_ to parallelize across subjects
   NJOBS=`wc -l < ${FULL_COHORT}`
   HEADER="$(head -n 1 $FULL_COHORT)"
   SIMG=/data/containers/xcpEngine.simg
+  TMPDIR=/path/to/your/tmp-directory
   # memory, CPU and time depend on the designfile and your dataset. Adjust values correspondingly
   XCP_MEM=0G
   XCP_C=0
   XCP_TIME=0:0:0
-  TMPDIR=/path/to/your/tmp-directory
+ 
 
   if [[ ${NJOBS} == 0 ]]; then
       exit 0
@@ -196,7 +197,7 @@ Using SLURM_ to parallelize across subjects
   EOF
   sbatch xcpParallel.sh
 
-Keep in mind that - next to the directories and settings you need to adjust in the beginning of the script as mentioned above - the path/to/your/working_directory needs to be defined and the ``logs`` directory needs to exist in your working-directory (see ``/path/to/your/working_directory/logs`` ). Furthermore the ``/home/user/data`` needs to be adjustet to your setting (see ``-B /home/user/data:/data``).
+Keep in mind that - next to the directories and settings you need to adjust in the beginning of the script as mentioned above - the path/to/your/working_directory needs to be defined and the ``logs`` directory needs to exist in your working-directory (see ``--workdir /path/to/your/working_directory`` and ``--output /path/to/your/working_directory/logs`` ). Furthermore ``/home/user/data`` needs to be adjusted to your system (see ``-B /home/user/data:/data``).
 
 NOTE
 

--- a/docs/containers/index.rst
+++ b/docs/containers/index.rst
@@ -201,8 +201,8 @@ Using SLURM_ to parallelize across subjects
 
 NOTE
 
-Depending on your design-file some modules refer by default to ``qsub`` (SGE_) which doenst exist in your container once you use ``SBATCH`` (SLURM_). The ``jfl`` module used for example in the [anat-antsct.dsn](https://github.com/PennBBL/xcpEngine/blob/master/designs/anat-antsct.dsn) has this setting ``jlf_parallel[3]=1``. The ``1`` refers to ``qsub`` here. Using ``SBATCH`` you have to change that setting. ``jlf_parallel[3]=0`` will solve the problem but will increase processing time significantly (you dont process parallel anymore but serial then). 
-by default (built into the container?) antsJointLabelFusion.sh is trying to use SGE qsub -c 1 Option and that fails because there is no qsub in the container 
+Depending on your design-file some modules refer by default to ``qsub`` (SGE_) which doenst exist in your container once you use ``SBATCH`` (SLURM_). The ``jfl`` module used for example in the ``anat-antsct.dsn``(https://github.com/PennBBL/xcpEngine/blob/master/designs/anat-antsct.dsn) has this setting ``jlf_parallel[3]=1``. The ``1`` refers to ``qsub`` here. Using ``SBATCH`` you have to change that setting. ``jlf_parallel[3]=0`` will solve the problem but will increase processing time significantly (you dont process parallel anymore but serial then). 
+
 
 
  

--- a/docs/containers/index.rst
+++ b/docs/containers/index.rst
@@ -87,14 +87,15 @@ substituted for ``-v``. Here is an example:::
 
 Mounting directories in Docker is easier than with Singularity.
 
+
 Parallelize across subjects
 ----------------------------------------
 
 By running xcpEngine from a container, you lose the ability to submit jobs
 to the cluster directly from xcpEngine. We provide two examplary ways to split your cohort
 file and submit either a ``qsub`` or an ``sbatch`` job for each line. 
-For illustrating reasons the SGE script uses a ``my_cohort_rel_container.csv`` -cohortfile 
-where as the SLURM script uses a ``host.csv`` -cohortfile. 
+For illustrating reasons the SGE_ script uses a ``my_cohort_rel_container.csv`` -cohortfile 
+where as the SLURM_ script uses a ``my_cohort_rel_host.csv`` -cohortfile. 
 
 .. _SGE:
 

--- a/docs/containers/index.rst
+++ b/docs/containers/index.rst
@@ -201,7 +201,7 @@ Using SLURM_ to parallelize across subjects
 
 NOTE
 
-Depending on your design-file some modules refer by default to ``qsub`` (SGE_) which doenst exist in your container once you use ``SBATCH`` (SLURM_). The ``jfl`` module used for example in the [anat-antsct.dsn](xcpEngine/designs/anat-antsct.dsn) has this setting ``jlf_parallel[3]=1``. The ``1`` refers to ``qsub`` here. Using ``SBATCH`` you have to change that setting. ``jlf_parallel[3]=0`` will solve the problem but will increase processing time significantly (you dont process parallel anymore but serial then). 
+Depending on your design-file some modules refer by default to ``qsub`` (SGE_) which doenst exist in your container once you use ``SBATCH`` (SLURM_). The ``jfl`` module used for example in the [anat-antsct.dsn](https://github.com/PennBBL/xcpEngine/blob/master/designs/anat-antsct.dsn) has this setting ``jlf_parallel[3]=1``. The ``1`` refers to ``qsub`` here. Using ``SBATCH`` you have to change that setting. ``jlf_parallel[3]=0`` will solve the problem but will increase processing time significantly (you dont process parallel anymore but serial then). 
 by default (built into the container?) antsJointLabelFusion.sh is trying to use SGE qsub -c 1 Option and that fails because there is no qsub in the container 
 
 

--- a/docs/containers/index.rst
+++ b/docs/containers/index.rst
@@ -94,7 +94,7 @@ Parallelize across subjects
 By running xcpEngine from a container, you lose the ability to submit jobs
 to the cluster directly from xcpEngine. We provide two examplary ways to split your cohort
 file and submit either a ``qsub`` (SGE_) or an ``sbatch`` (SLURM_)  -job for each line. 
-For illustrating reasons the two different scripts refer to different cohort files: The SGE 
+For illustrating reasons the two different scripts refer to different cohort-file-types: The SGE 
 script uses a ``my_cohort_rel_container.csv`` cohortfile, which means we **don't need** to 
 specify an ``-r`` flag. The SLURM script uses a ``my_cohort_rel_host.csv`` cohortfile, which 
 means we **need** to specify an ``-r`` flag.

--- a/docs/containers/index.rst
+++ b/docs/containers/index.rst
@@ -162,6 +162,7 @@ Using SLURM_ to parallelize across subjects
   XCP_MEM=0G
   XCP_C=0
   XCP_TIME=0:0:0
+  TMPDIR=/path/to/your/tmp-directory
 
   if [[ ${NJOBS} == 0 ]]; then
       exit 0
@@ -174,8 +175,8 @@ Using SLURM_ to parallelize across subjects
   #SBATCH --mem $XCP_MEM
   #SBATCH -c $XCP_C
   #SBATCH --time $XCP_TIME
-  #SBATCH --workdir /my_working_directory
-  #SBATCH --output /my_working_directory/logs/slurm-%A_%a.out
+  #SBATCH --workdir /path/to/your/working_directory
+  #SBATCH --output /path/to/your/working_directory/logs/slurm-%A_%a.out
 
 
   LINE_NUM=\$( expr \$SLURM_ARRAY_TASK_ID + 1 )
@@ -184,17 +185,22 @@ Using SLURM_ to parallelize across subjects
   echo $HEADER > \$TEMP_COHORT
   echo \$LINE >> \$TEMP_COHORT 
 
-  singularity run -B /home/user/data:/data $SIMG \\
+  singularity run -B /home/user/data:/data \\
+    -B $TMPDIR:/tmp $SIMG \\
     -d /data/study/my_design.dsn \\
     -c \${TEMP_COHORT} \\
     -o /data/study/output \\
     -r /data \\
-    -i \$TMPDIR
+    -i /tmp
 
   EOF
   sbatch xcpParallel.sh
 
-Keep in mind that - next to the directories and settings you need to adjust as mentioned in the script above - the ``logs`` directory needs to exist in your working-directory (see ``/my_working_directory/logs`` ) and you need to define the ``TMPDIR`` variable (see ``$TMPDIR``). 
+Keep in mind that - next to the directories and settings you need to adjust in the beginning of the script as mentioned above - the path/to/your/working_directory needs to be defined and the ``logs`` directory needs to exist in your working-directory (see ``/path/to/your/working_directory/logs`` ). Furthermore the ``/home/user/data`` needs to be adjustet to your setting (see ``-B /home/user/data:/data``).
+
+NOTE
+
+
 
  
 

--- a/docs/containers/index.rst
+++ b/docs/containers/index.rst
@@ -93,7 +93,7 @@ Parallelize across subjects
 
 By running xcpEngine from a container, you lose the ability to submit jobs
 to the cluster directly from xcpEngine. We provide two examplary ways to split your cohort
-file and submit either a ``qsub`` (SGE_) or an ``sbatch`` (SLURM_) job for each line. 
+file and submit either a ``qsub`` (SGE_) or an ``sbatch`` (SLURM_)  -job for each line. 
 For illustrating reasons the two different scripts refer to different cohort files: The SGE 
 script uses a ``my_cohort_rel_container.csv`` -cohortfile, which means we **don't need** to 
 specify an ``-r`` flag. The SLURM script uses a ``my_cohort_rel_host.csv`` -cohortfile, which 

--- a/docs/containers/index.rst
+++ b/docs/containers/index.rst
@@ -201,6 +201,8 @@ Using SLURM_ to parallelize across subjects
 
 NOTE
 
+Depending on your design-file some modules refer by default to ``qsub`` (SGE_) which doenst exist in your container once you use ``SBATCH`` (SLURM_). The ``jfl`` module used for example in the anat-antsct.dsn[https://github.com/PennBBL/xcpEngine/blob/master/designs/anat-antsct.dsn]has this setting ``jlf_parallel[3]=1``. The ``1`` refers to ``qsub`` here. Using ``SBATCH`` you have to change that setting. ``jlf_parallel[3]=0`` will solve the problem but will increase processing time significantly (you dont process parallel anymore but serial then). 
+by default (built into the container?) antsJointLabelFusion.sh is trying to use SGE qsub -c 1 Option and that fails because there is no qsub in the container 
 
 
  

--- a/docs/containers/index.rst
+++ b/docs/containers/index.rst
@@ -197,7 +197,7 @@ Using SLURM_ to parallelize across subjects
   EOF
   sbatch xcpParallel.sh
 
-Keep in mind that - next to the directories and settings you need to adjust in the beginning of the script as mentioned above - the ``/path/to/your/working_directory`` needs to be defined and the ``logs`` directory needs to exist in your working-directory (see ``--workdir /path/to/your/working_directory`` and ``--output /path/to/your/working_directory/logs/slurm-%A_%a.out`` ). Furthermore ``/home/user/data`` needs to be adjusted to your system (see ``-B /home/user/data:/data``).
+
 
 NOTE
 

--- a/docs/containers/index.rst
+++ b/docs/containers/index.rst
@@ -87,16 +87,24 @@ substituted for ``-v``. Here is an example:::
 
 Mounting directories in Docker is easier than with Singularity.
 
-
-Using SGE to parallelize across subjects
+Parallelize across subjects
 ----------------------------------------
 
 By running xcpEngine from a container, you lose the ability to submit jobs
-to the cluster directly from xcpEngine. Here is a way to split your cohort
-file and submit a qsub job for each line. Note that we are using
-``my_cohort_rel_container.csv``, which means we don't need to specify
-an ``-r`` flag. If your cohort file uses paths relative to the host's
-file system you will need to specify ``-r``::
+to the cluster directly from xcpEngine. We provide two examplary ways to split your cohort
+file and submit either a ``qsub`` or an ``sbatch`` job for each line. 
+For illustrating reasons the SGE script uses a ``my_cohort_rel_container.csv`` -cohortfile 
+where as the SLURM script uses a ``host.csv`` -cohortfile. 
+
+.. _SGE:
+
+Using SGE_ to parallelize across subjects
+----------------------------------------
+
+Note that we are using ``my_cohort_rel_container.csv``, which means we don't
+need to specify an ``-r`` flag. If your cohort file uses paths relative to 
+the host's file system you will need to specify ``-r`` (see SLURM_).
+::
 
   #!/bin/bash
   FULL_COHORT=/data/study/my_cohort_rel_container.csv
@@ -135,10 +143,13 @@ file system you will need to specify ``-r``::
 
 You will need to collate group-level outputs after batching subjects with the script ``${XCPEDIR}/utils/combineOutput`` script, provided in ``utils``.
 
+.. _SLURM:
 
 Using SLURM to parallelize across subjects
 ----------------------------------------
-By running xcpEngine from a container, you lose the ability to submit jobs to the cluster directly from xcpEngine. Here is a way to split your cohort file and submit an sbatch job for each line. Note that we are using ``my_cohort_rel_host.csv``, which means we need to specify an ``-r`` flag. If your cohort file uses paths relative to the container you dont need to specify ``-r``.
+Note that we are using ``my_cohort_rel_host.csv``, which means we need to specify
+an ``-r`` flag. If your cohort file uses paths relative to the container you dont
+need to specify ``-r`` (see SGE_).
 ::
 
   #!/bin/bash

--- a/docs/containers/index.rst
+++ b/docs/containers/index.rst
@@ -93,18 +93,19 @@ Parallelize across subjects
 
 By running xcpEngine from a container, you lose the ability to submit jobs
 to the cluster directly from xcpEngine. We provide two examplary ways to split your cohort
-file and submit either a ``qsub`` or an ``sbatch`` job for each line. 
-For illustrating reasons the SGE_ script uses a ``my_cohort_rel_container.csv`` -cohortfile 
-where as the SLURM_ script uses a ``my_cohort_rel_host.csv`` -cohortfile. 
+file and submit either a ``qsub`` (SGE_) or an ``sbatch`` (SLURM_) job for each line. 
+For illustrating reasons the two different scripts refer to different cohort files: The SGE 
+script uses a ``my_cohort_rel_container.csv`` -cohortfile, which means we **don't need** to 
+specify an ``-r`` flag. The SLURM script uses a ``my_cohort_rel_host.csv`` -cohortfile, which 
+means we **need** to specify an ``-r`` flag.
+Note for both scripts: You will need to collate group-level outputs after batching subjects
+with the ``${XCPEDIR}/utils/combineOutput`` script, provided in ``utils``.
 
 .. _SGE:
 
 Using SGE_ to parallelize across subjects
 ----------------------------------------
 
-Note that we are using ``my_cohort_rel_container.csv``, which means we don't
-need to specify an ``-r`` flag. If your cohort file uses paths relative to 
-the host's file system you will need to specify ``-r`` (see SLURM_).
 ::
 
   #!/bin/bash
@@ -142,15 +143,13 @@ the host's file system you will need to specify ``-r`` (see SLURM_).
   qsub xcpParallel.sh
 
 
-You will need to collate group-level outputs after batching subjects with the script ``${XCPEDIR}/utils/combineOutput`` script, provided in ``utils``.
+
 
 .. _SLURM:
 
 Using SLURM to parallelize across subjects
 ----------------------------------------
-Note that we are using ``my_cohort_rel_host.csv``, which means we need to specify
-an ``-r`` flag. If your cohort file uses paths relative to the container you dont
-need to specify ``-r`` (see SGE_).
+
 ::
 
   #!/bin/bash
@@ -196,7 +195,7 @@ need to specify ``-r`` (see SGE_).
   sbatch xcpParallel.sh
 
 Keep in mind that - next to the directories and settings you need to adjust as mentioned in the script above - the ``logs`` directory needs to exist in your working-directory (see ``/my_working_directory/logs`` ) and you need to define the ``TMPDIR`` variable (see ``$TMPDIR``). 
-You will need to collate group-level outputs after batching subjects with the script ``${XCPEDIR}/utils/combineOutput`` script, provided in ``utils``.
+
  
 
 Using the bundled software

--- a/docs/containers/index.rst
+++ b/docs/containers/index.rst
@@ -89,7 +89,7 @@ Mounting directories in Docker is easier than with Singularity.
 
 
 Parallelize across subjects
-=================================
+-----------------------------
 
 By running xcpEngine from a container, you lose the ability to submit jobs
 to the cluster directly from xcpEngine. We provide two examplary ways to split your cohort
@@ -104,7 +104,7 @@ with the ``${XCPEDIR}/utils/combineOutput`` script, provided in ``utils``.
 .. _SGE:
 
 Using SGE_ to parallelize across subjects
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^
 
 ::
 
@@ -148,7 +148,7 @@ Using SGE_ to parallelize across subjects
 .. _SLURM:
 
 Using SLURM_ to parallelize across subjects
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^
 
 ::
 


### PR DESCRIPTION
Dear PennBBL,

please consider my pull request. It fixes the following things:
- by changing the structure to `Parallelize across subjects` as the header and `SGE` and `SLURM` as subtopics redundant information can be avoided
- I changed the order of the SLURM script a little so that it is more obvious what needs to be adjusted to individual systems/ preferences
- I added an important information for people using SLURM and anatomical pipeline 